### PR TITLE
S8 scia 2023

### DIFF
--- a/src/lib/pegasus/coefficients/index.js
+++ b/src/lib/pegasus/coefficients/index.js
@@ -2,9 +2,11 @@ import { SEMESTER_FILTER, YEAR_FILTER } from '../documents';
 
 const S7_2023 = Symbol('S7 (2023)');
 const S6_2024 = Symbol('S6 (2024)');
+const S8_SCIA_2023 = Symbol('S8 SCIA (2023)');
 
 const coefficients = {
-    [S6_2024]: (await import('./s6_2024')).default
+    [S6_2024]: (await import('./s6_2024')).default,
+    [S8_SCIA_2023]: (await import('./s8_SCIA_2023')).default
 };
 
 export function computeAverages(filters, marks)
@@ -113,6 +115,8 @@ function getCoefficients(filters)
                     return coefficients[S6_2024];
                 case 'SI7':
                     return coefficients[S7_2023];
+                case 'SI8':
+                    return coefficients[S8_SCIA_2023];
             }
             break;
     }

--- a/src/lib/pegasus/coefficients/s8_SCIA_2023.js
+++ b/src/lib/pegasus/coefficients/s8_SCIA_2023.js
@@ -92,4 +92,4 @@ export default {
             _subject: 1/7
         }
     }
-}
+};

--- a/src/lib/pegasus/coefficients/s8_SCIA_2023.js
+++ b/src/lib/pegasus/coefficients/s8_SCIA_2023.js
@@ -71,5 +71,25 @@ export default {
             'QCM SCALA': 1/2,
             'PROJET': 1/2
         }
+    },
+    IAML8: {
+        FTML_S8: {
+            _subject: 1.5/7
+        },
+        IREN: {
+            _subject: 1/7
+        },
+        MLBIO: {
+            _subject: 1/7
+        },
+        MLSECU: {
+            _subject: 1/7
+        },
+        PTML_S8: {
+            _subject: 1/7
+        },
+        VLG: {
+            _subject: 1/7
+        }
     }
 }

--- a/src/lib/pegasus/coefficients/s8_SCIA_2023.js
+++ b/src/lib/pegasus/coefficients/s8_SCIA_2023.js
@@ -1,0 +1,31 @@
+export default {
+    MCE8: {
+        COINM: {
+            _subject: 1/7
+        },
+        DBRE: {
+            _subject: 1/7
+        },
+        DPES: {
+            _subject: 1/14,
+            'DPES_NOTE_TD_COLLABORATION': 1/3,
+            'DPES_NOTE_OBJECTIF': 1/3,
+            'DPES_NOTE_VIDEO': 1/3
+        },
+        M_CRIN: {
+            _subject: 1/7
+        },
+        MPRO: {
+            _subject: 1/7
+        },
+        PFE_SCIA: {
+            _subject: 1/7
+        },
+        PIFI: {
+            _subject: 1/7
+        },
+        RE_S8: {
+            _subject: 1/14
+        }
+    }
+}

--- a/src/lib/pegasus/coefficients/s8_SCIA_2023.js
+++ b/src/lib/pegasus/coefficients/s8_SCIA_2023.js
@@ -46,5 +46,30 @@ export default {
         REMA1: {
             _subject: 1/7
         }
+    },
+    IAOT8: {
+        AMS1: {
+            _subject: 1.5/9
+        },
+        OCVX1: {
+            _subject: 2/9,
+            'OCVX1_EXAMEN': 0.4,
+            'OCVX1_MOODLE': 0.2,
+            'OCVX1_TP': 0.4
+        },
+        PRST: {
+            _subject: 1.5/9
+        },
+        PYBD: {
+            _subject: 1/9
+        },
+        RAND: {
+            _subject: 1.5/9
+        },
+        SCALA: {
+            _subject: 1.5/9,
+            'QCM SCALA': 1/2,
+            'PROJET': 1/2
+        }
     }
 }

--- a/src/lib/pegasus/coefficients/s8_SCIA_2023.js
+++ b/src/lib/pegasus/coefficients/s8_SCIA_2023.js
@@ -7,7 +7,7 @@ export default {
             _subject: 1/7
         },
         DPES: {
-            _subject: 1/14,
+            _subject: 0.5/7,
             'DPES_NOTE_TD_COLLABORATION': 1/3,
             'DPES_NOTE_OBJECTIF': 1/3,
             'DPES_NOTE_VIDEO': 1/3
@@ -25,7 +25,26 @@ export default {
             _subject: 1/7
         },
         RE_S8: {
-            _subject: 1/14
+            _subject: 0.5/7
+        }
+    },
+    IAET8: {
+        BIDA: {
+            _subject: 2/7
+        },
+        HADSPA: {
+            _subject: 1.5/7,
+            'QCM SPARK': 1/2,
+            'PROJET': 1/2
+        },
+        IAZU: {
+            _subject: 1.5/7
+        },
+        MPDS_S8: {
+            _subject: 1/7
+        },
+        REMA1: {
+            _subject: 1/7
         }
     }
 }


### PR DESCRIPTION
I added the S8 SCIA 2023 coefficients in `src/lib/pegasus/coefficients/s8_SCIA_2023.js` and update the `src/lib/pegasus/coefficients/index.js` file with them.

As I didn't find an attribute `class` or `majeure` in the `filters` parameter of the method `getCoefficients`, I had to return the S8 SCIA 2023 ones on the case of semester `SI8`.

Please fix my updates to the JS code if this isn't the expected behavior. Thank you.