### PR TITLE
Update APXF and INTG coefs

### DIFF
--- a/src/lib/pegasus/coefficients/s5_2025.js
+++ b/src/lib/pegasus/coefficients/s5_2025.js
@@ -37,7 +37,7 @@ export default {
             _subject: 2,
 
             // TODO: Is this correct?
-            '.* CC1': 2/20,
+            '.* EF': 2/20,
             '.* DM': 6/20,
             '.*': 12/20
         },
@@ -54,7 +54,7 @@ export default {
         INT: {
             '.* CC1': 0.4 * 0.8,
             '.* CC2': 0.6 * 0.8,
-            '.*': 1/2 * 0.2
+            '.*': 0.2
         }
     },
     MAT1: {


### PR DESCRIPTION
INTG : il y a bien deux evals formatives mais dans le pdf des notes elles sont déjà fusionnées (la moyenne des deux) et il y a qu'une note qui représente les deux évals formatives. Donc le 1/2 était en trop ligne 57.

APXF : les noms ont changé dans le pdf des notes : c'est "DM", "exam" et "EF" maintenant. J'ai mis à jour la ligne 40.