### PR TITLE
feat(infinity-pegasus/coefficients): add coefficients for the APPING/EXP2

### DIFF
--- a/src/lib/pegasus/coefficients/index.js
+++ b/src/lib/pegasus/coefficients/index.js
@@ -4,6 +4,9 @@ const S5_2026 = Symbol('S5 (2026)');
 const S5_APP_ING_2026 = Symbol('S5 [APP ING] (2026)');
 const S6_2026 = Symbol('S6 (2026)');
 const S6_APP_ING_2026 = Symbol('S6 [APP ING] (2026)');
+const S7_APP_ING_CYB2_2025 = Symbol('S7 [CYB2] (2025)');
+const S7_APP_ING_DEV2_2025 = Symbol('S7 [DEV2] (2025)');
+const S7_APP_ING_EXP2_2025 = Symbol('S7 [EXP2] (2025)');
 const S8_GISTRE_2025 = Symbol('S8 [GISTRE] (2025)');
 
 const coefficients = {
@@ -12,6 +15,9 @@ const coefficients = {
     [S6_2026]: (await import('./s6_2026')).default,
     [S6_APP_ING_2026]: (await import('./s6_app_ing_2026')).default,
     [S8_GISTRE_2025]: (await import('./s8_gistre_2025.js')).default,
+    [S7_APP_ING_CYB2_2025]: (await import('./s7_cyb2_2025.js')).default,
+    [S7_APP_ING_DEV2_2025]: (await import('./s7_dev2_2025.js')).default,
+    [S7_APP_ING_EXP2_2025]: (await import('./s7_exp2_2025.js')).default,
 };
 
 export function computeAverages(filters, marks)
@@ -124,6 +130,12 @@ function getCoefficients(filters)
                     return coefficients[S5_APP_ING_2026];
                 case 'SA6':
                     return coefficients[S6_APP_ING_2026];
+                case 'SA7':
+                    return coefficients[S7_APP_ING_CYB2_2025];
+                case 'SD7':
+                    return coefficients[S7_APP_ING_DEV2_2025];
+                case 'SX7':
+                    return coefficients[S7_APP_ING_EXP2_2025];
                 case 'SI8GISTRE':
                     return coefficients[S8_GISTRE_2025];
             }

--- a/src/lib/pegasus/coefficients/s7_cyb2_2025.js
+++ b/src/lib/pegasus/coefficients/s7_cyb2_2025.js
@@ -1,0 +1,75 @@
+// ----------------------
+// READ ME!
+// ----------------------
+//
+// Both ID and names can be used for both subjects and marks (marks ID are their order in the list)
+// Subjects or marks with a coefficient of 1 (or equivalent) can be omitted
+// Coefficient does not have to sum up to 1, since the sum of the coefficients will be used
+// No need to specify module coefficients, since they are already retrieved from the PDF
+// Also, regex are supported for marks name :^) (which means '[' must be escaped !)
+
+// TODO: This was imported from past year, it will need to be updated when the syllabus is released
+
+export default {
+  MAIF3: {
+    A_PROD: {
+      _subject: 1.5,
+    },
+    A_COCO: {
+      _subject: 1.5,
+    }
+  },
+  GLPS3: {
+    A_CLAN: {
+      _subject: 1,
+    },
+    A_IBMZ1: {
+      _subject: 1.5,
+    },
+    A_PPEX3: {
+      _subject: 1,
+    },
+    ASSE: {
+      _subject: 1.5,
+    },
+    A_P_42SH: {
+      _subject: 1,
+    }
+  },
+  SIS3: {
+    A_DEVSEC: {
+      _subject: 2,
+    },
+    A_KERN: {
+      _subject: 2,
+    },
+    A_A_PENT: {
+      _subject: 2,
+    },
+    A_ARS1: {
+      _subject: 1.5,
+    },
+    A_NMSS: {
+      _subject: 1.5,
+    }
+  },
+  MCE3: {
+    'A_ANGL-3': {
+      _subject: 1,
+    },
+    X_COLIN: {
+      _subject: 1,
+    },
+    A_GPROAA: {
+      _subject: 1,
+    },
+    A_DRTR: {
+      _subject: 1,
+    }
+  },
+  AEE3: {
+    A_EAE3: {
+      _subject: 8
+    }
+  }
+};

--- a/src/lib/pegasus/coefficients/s7_dev2_2025.js
+++ b/src/lib/pegasus/coefficients/s7_dev2_2025.js
@@ -1,0 +1,13 @@
+// ----------------------
+// READ ME!
+// ----------------------
+//
+// Both ID and names can be used for both subjects and marks (marks ID are their order in the list)
+// Subjects or marks with a coefficient of 1 (or equivalent) can be omitted
+// Coefficient does not have to sum up to 1, since the sum of the coefficients will be used
+// No need to specify module coefficients, since they are already retrieved from the PDF
+// Also, regex are supported for marks name :^) (which means '[' must be escaped !)
+
+// TODO: Fill when available 
+export default {
+};

--- a/src/lib/pegasus/coefficients/s7_exp2_2025.js
+++ b/src/lib/pegasus/coefficients/s7_exp2_2025.js
@@ -1,0 +1,61 @@
+// ----------------------
+// READ ME!
+// ----------------------
+//
+// Both ID and names can be used for both subjects and marks (marks ID are their order in the list)
+// Subjects or marks with a coefficient of 1 (or equivalent) can be omitted
+// Coefficient does not have to sum up to 1, since the sum of the coefficients will be used
+// No need to specify module coefficients, since they are already retrieved from the PDF
+// Also, regex are supported for marks name :^) (which means '[' must be escaped !)
+
+// TODO: This was imported from past year, it will need to be updated when the syllabus is released
+
+export default {
+  GLPS3: {
+    X_SOCRA: {
+      _subject: 1.5,
+    },
+    X_PPEX3: {
+      _subject: 1.5,
+    },
+    X_BAGD1: {
+      _subject: 2,
+    },
+    X_JEE: {
+      _subject: 2,
+    }
+  },
+  PWM1: {
+    X_WEB: {
+      _subject: 3,
+    },
+    X_P_WEB: {
+      _subject: 2,
+    },
+    X_IJST: {
+      _subject: 1,
+    },
+    X_UXUI: {
+      _subject: 2,
+    },
+    X_IANDO: {
+      _subject: 2
+    }
+  },
+  MCE3: {
+    'X_ANGL-3': {
+      _subject: 1.5,
+    },
+    X_GPROAA: {
+      _subject: 1.5,
+    },
+    X_DRTR: {
+      _subject: 1,
+    }
+  },
+  AEE3: {
+    X_EAE3: {
+      _subject: 9
+    }
+  }
+};


### PR DESCRIPTION
Added coefficients for the APPING 2, now renamed CYB2 and the EXP2 that are now separated in 2 categories EXP2 and DEV2.
Still waiting for the OFA to create the DEV2 report card before adding the coef