### PR TITLE
Make the ID optional when parsing a module

### DIFF
--- a/src/lib/pegasus/coefficients/s5_2027.js
+++ b/src/lib/pegasus/coefficients/s5_2027.js
@@ -12,7 +12,7 @@
 
 export default {
     // même id pour harmo info et maths
-    Harmonisation: {
+    "Harmonisation Concevoir": {
         APXF: {
             _subject: 2,
             'Examen 1': 0.8 * 0.4,          // ES1

--- a/src/lib/pegasus/marks.js
+++ b/src/lib/pegasus/marks.js
@@ -10,7 +10,7 @@ import { getDocuments, MARKS_DOCUMENT, REPORT_DOCUMENT } from './documents';
 // - '[ID]-Module name [X ECTS]'
 // - 'ID Module name [X ECTS]'
 // - 'ID_Module name [X ECTS]'
-const MODULE_REGEX = /(\[?([a-zA-Z0-9]+)\]? ?-? ?_?)?(.*) *\[ *(.*) ECTS]/;
+const MODULE_REGEX = /(?:\[(.+)\] |(.+)_|(.+) - |\[(.+)\] - |\[(.+)\]-|([A-Z0-1]+) )?(.*) +\[ *(.*) ECTS\]/;
 const MARK_REGEX = /\d+,\d\d/g;
 const POSITION_THRESHOLD = 5;
 
@@ -91,7 +91,15 @@ async function parsePage(page, result, report)
         }
 
         while (i < texts.length && texts[i].match(MODULE_REGEX)) {
-            const [,, id, name, credits] = texts[i++].match(MODULE_REGEX);
+            let id, name, credits
+
+            const regexGroups = texts[i++].match(MODULE_REGEX).filter(s => !!s);
+
+            if (regexGroups.length == 3)
+                [, name, credits] = regexGroups;
+            else
+                [, id, name, credits] = regexGroups;
+
             const subjects = [];
             let grade, average, classAverage;
 


### PR DESCRIPTION
# Goal
With the current parsing, the first word of the module name is interpreted as an ID. However there are some modules without any ID and / or with multiple words. This fix changes the regex so that the ID is now parsed as intended:
  - 'ID - Module name [X ECTS]'
  - '[ID] Module name [X ECTS]'
  - '[ID] - Module name [X ECTS]'
  - '[ID]-Module name [X ECTS]'
  - 'ID Module name [X ECTS]'
  - 'ID_Module name [X ECTS]'

# Regex
## Old regex
![image](https://github.com/user-attachments/assets/c5282de1-c207-4d74-955c-fe685da713d3)

## New regex
![image](https://github.com/user-attachments/assets/c40878cd-e2f3-4e17-96ab-879f83de2168)

# Context
In my Promo (2027) the modules can have multiple words and do not have ID for most of them. Therefore their name and ID are mixed up and sometimes they only have an ID and no name (name is considered as an ID).